### PR TITLE
Name attr_accessor 'invisible' instead of 'synced'

### DIFF
--- a/lib/invisible.rb
+++ b/lib/invisible.rb
@@ -72,15 +72,15 @@ maintain their original visibility.
   end
 
   def prepend_features(base)
-    return super if synced
+    return super if invisible
 
     sync_visibility(base, mod = dup)
-    mod.synced = true
+    mod.invisible = true
     base.prepend mod
   end
 
   protected
-  attr_accessor :synced
+  attr_accessor :invisible
 
   private
 


### PR DESCRIPTION
Less likely to clobber something this way.