### PR TITLE
Give a name to prepended module

### DIFF
--- a/lib/invisible.rb
+++ b/lib/invisible.rb
@@ -76,6 +76,7 @@ maintain their original visibility.
 
     sync_visibility(base, mod = dup)
     mod.invisible = true
+    base.const_set("Invisible#{name}", mod) if base.name && name
     base.prepend mod
   end
 

--- a/spec/invisible_spec.rb
+++ b/spec/invisible_spec.rb
@@ -71,6 +71,15 @@ describe Invisible do
         expect { instance.private_method }.to raise_error(NoMethodError, /private method `private_method' called/)
         expect(instance.send(:private_method)).to eq('private with foo')
       end
+
+      it 'gives prepended module a name if both prepending class and module have names' do
+        stub_const('Foo', base_class)
+        stub_const('Bar', invisible_mod)
+
+        base_class.prepend invisible_mod
+
+        expect(base_class.ancestors.first.name).to eq('Foo::InvisibleBar')
+      end
     end
   end
 end


### PR DESCRIPTION
Currently, when you use `prepend` on an invisible module, you get a dup'ed copy of the module in the class' ancestors, because Invisible has to copy the original module and change method visibility to match the prepending class.

This change gives a name to this dup'ed mod so it's easier to recognize in the class' ancestors.