### PR TITLE
Only prepend dup'ed module once if possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Public? Private? Protected? Who cares! I just wanna monkey patch that shit!
 
-No fear: Invisible has your back! This little ten-line gem does away with the problem of maintaining original method visibility, so you can get on with your monkey-patching mayhem.
+No fear: Invisible has your back! This little gem does away with the problem of maintaining original method visibility, so you can get on with your monkey-patching mayhem. It does this with only a dozen lines of code.
 
 ## Usage
 

--- a/lib/invisible.rb
+++ b/lib/invisible.rb
@@ -74,9 +74,15 @@ maintain their original visibility.
   def prepend_features(base)
     return super if invisible
 
-    sync_visibility(base, mod = dup)
+    mod = dup
+
+    if name
+      return if base.const_defined?(mod_name = "Invisible#{name}")
+      base.const_set(mod_name, mod)
+    end
+
+    sync_visibility(base, mod)
     mod.invisible = true
-    base.const_set("Invisible#{name}", mod) if base.name && name
     base.prepend mod
   end
 

--- a/spec/invisible_spec.rb
+++ b/spec/invisible_spec.rb
@@ -80,6 +80,14 @@ describe Invisible do
 
         expect(base_class.ancestors.first.name).to eq('Foo::InvisibleBar')
       end
+
+      it 'only prepends module once if mod has a name' do
+        stub_const('Bar', invisible_mod)
+
+        base_class.prepend invisible_mod
+
+        expect { base_class.prepend invisible_mod }.not_to change { base_class.ancestors.size }
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,9 @@ RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = '.rspec_status'
 
+  config.filter_run focus: true
+  config.run_all_when_everything_filtered = true
+
   # Disable RSpec exposing methods globally on `Module` and `main`
   # config.disable_monkey_patching!
 


### PR DESCRIPTION
Normally, you can prepend a module many times and it will only actually be prepended once. But if you `extend Invisible`, your module will now not obey this rule.

This change fixes this *given the module has a name*. If it has no name, this would be more complicated to do, so I'm just going to make that assumption, which holds true for most cases.