### PR TITLE
Only include dup'ed mod if prepending class has different visibility

### DIFF
--- a/spec/invisible_spec.rb
+++ b/spec/invisible_spec.rb
@@ -88,6 +88,27 @@ describe Invisible do
 
         expect { base_class.prepend invisible_mod }.not_to change { base_class.ancestors.size }
       end
+
+      it 'prepends original module if visibility for all methods match prepending class' do
+        mod = Module.new do
+          protected
+
+          def protected_method
+            super + ' with bar'
+          end
+
+          private
+
+          def private_method
+            super + ' with bar'
+          end
+        end
+
+        base_class.prepend mod
+
+        expect { base_class.prepend mod }.not_to change { base_class.ancestors.size }
+        expect(base_class.ancestors.first).to eq(mod)
+      end
     end
   end
 end


### PR DESCRIPTION
We don't have to dup the invisible module if there is no visibility conflict.